### PR TITLE
#149470705 Change license author field into a choice field

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn wger.wsgi:application --log-file -
+web: python manage.py makemigrations && python manage.py migrate && gunicorn wger.wsgi:application --log-file -

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn wger.wsgi:application --log-file -
+web: ./deploy.sh

--- a/deploy.sh
+++ b/deploy.sh
@@ -1,0 +1,1 @@
+pip install wger && wger create_settings && python manage.py makemigrations && python manage.py migrate && gunicorn wger.wsgi:application --log-file -

--- a/wger/utils/models.py
+++ b/wger/utils/models.py
@@ -37,8 +37,8 @@ class AbstractLicenseModel(models.Model):
                                 verbose_name=_('License'),
                                 default=2)
     '''The item's license'''
-    from django.contrib.auth.models import User
-    user_list = [(user.username, user.username) for user in User.objects.all()]
+    from wger.core.models import UserProfile
+    user_list = [(user_profile.user.username, user_profile.user.username) for user_profile in UserProfile.objects.all()]
 
     license_author = models.CharField(choices=user_list,
                                       max_length=50,

--- a/wger/utils/models.py
+++ b/wger/utils/models.py
@@ -37,15 +37,16 @@ class AbstractLicenseModel(models.Model):
                                 verbose_name=_('License'),
                                 default=2)
     '''The item's license'''
+    from django.contrib.auth.models import User
+    user_list = [(user.username, user.username) for user in User.objects.all()]
 
-    license_author = models.CharField(verbose_name=_('Author'),
+    license_author = models.CharField(choices=user_list,
                                       max_length=50,
                                       blank=True,
                                       null=True,
                                       help_text=_('If you are not the author, enter the name or '
                                                   'source here. This is needed for some licenses '
                                                   'e.g. the CC-BY-SA.'))
-    '''The author if it is not the uploader'''
 
 
 class AbstractSubmissionModel(models.Model):


### PR DESCRIPTION
#### What does this PR do?
Changes the license-author form field to a drop down.
#### Description of Task to be completed?
When adding a license author during the creation of an exercise, the user should select the author from a drop down list of users.
#### Any background context you want to provide?
Currently, license author is typed in an input text field.
#### What are the relevant pivotal tracker stories?
#149470705
#### Screenshots (if appropriate)
<img width="770" alt="screen shot 2017-08-02 at 16 10 20" src="https://user-images.githubusercontent.com/25482404/28875174-486cc168-779d-11e7-9b8f-89072dc8fab8.png">
