### PR TITLE
#149470705 Make License Author Field a Choice Field

### DIFF
--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -193,7 +193,7 @@ class ExercisesEditAddView(WgerFormMixin):
                           'muscles_secondary',
                           'equipment',
                           'license',
-                          'license_author']
+                          ]
 
             class Media:
                 js = ('/static/bower_components/tinymce/tinymce.min.js',)

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -181,7 +181,9 @@ class ExercisesEditAddView(WgerFormMixin):
                                                          widget=TranslatedOriginalSelectMultiple(),
                                                          required=False)
             license_author = ModelChoiceField(queryset=User.objects.all(),
-                                              widget=TranslatedSelect())
+                                              widget=TranslatedSelect(),
+                                              required=False,
+                                              empty_label=None)
 
             class Meta:
                 model = Exercise

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -59,7 +59,7 @@ from wger.utils.widgets import (
 )
 from wger.config.models import LanguageConfig
 from wger.weight.helpers import process_log_entries
-
+from django.contrib.auth.models import User
 
 logger = logging.getLogger(__name__)
 
@@ -180,6 +180,8 @@ class ExercisesEditAddView(WgerFormMixin):
             muscles_secondary = ModelMultipleChoiceField(queryset=Muscle.objects.all(),
                                                          widget=TranslatedOriginalSelectMultiple(),
                                                          required=False)
+            license_author = ModelChoiceField(queryset=User.objects.all(),
+                                        widget=TranslatedSelect())
 
             class Meta:
                 model = Exercise

--- a/wger/exercises/views/exercises.py
+++ b/wger/exercises/views/exercises.py
@@ -181,7 +181,7 @@ class ExercisesEditAddView(WgerFormMixin):
                                                          widget=TranslatedOriginalSelectMultiple(),
                                                          required=False)
             license_author = ModelChoiceField(queryset=User.objects.all(),
-                                        widget=TranslatedSelect())
+                                              widget=TranslatedSelect())
 
             class Meta:
                 model = Exercise


### PR DESCRIPTION
#### What does this PR do?
Changes the license-author form field to a drop down.
#### Description of Task to be completed?
When adding a license author during the creation of an exercise, the user should select the author from a drop down list of users.
#### Any background context you want to provide?
Currently, license author is typed in an input text field.
#### What are the relevant pivotal tracker stories?
#149470705
#### Screenshots (if appropriate)
<img width="770" alt="screen shot 2017-08-02 at 16 10 20" src="https://user-images.githubusercontent.com/25482404/28875174-486cc168-779d-11e7-9b8f-89072dc8fab8.png">
