### PR TITLE
#149470685 reset-muscle-exercise-cache.

### DIFF
--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -43,10 +43,14 @@ class MuscleListView(ListView):
     '''
     Overview of all muscles and their exercises
     '''
-    model = Muscle
-    queryset = Muscle.objects.all().order_by('-is_front', 'name'),
     context_object_name = 'muscle_list'
     template_name = 'muscles/overview.html'
+
+    def get_queryset(self):
+        '''Get the new set of muscles after cache refresh.
+        '''
+        queryset = Muscle.objects.all().order_by('-is_front', 'name')
+        return queryset,
 
     def get_context_data(self, **kwargs):
         '''
@@ -121,4 +125,5 @@ class MuscleDeleteView(WgerDeleteMixin, LoginRequiredMixin, PermissionRequiredMi
         context['title'] = _(u'Delete {0}?').format(self.object.name)
         context['form_action'] = reverse('exercise:muscle:delete', kwargs={
                                          'pk': self.kwargs['pk']})
+        cache.clear()
         return context

--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -63,7 +63,7 @@ class MuscleListView(ListView):
         return context
 
 
-class MuscleAdminListView(LoginRequiredMixin, PermissionRequiredMixin, MuscleListView):
+class MuscleAdminListView(LoginRequiredMixin, PermissionRequiredMixin, ListView):
     '''
     Overview of all muscles, for administration purposes
     '''

--- a/wger/exercises/views/muscles.py
+++ b/wger/exercises/views/muscles.py
@@ -19,6 +19,7 @@ from django.contrib.auth.mixins import PermissionRequiredMixin, LoginRequiredMix
 from django.core.urlresolvers import reverse, reverse_lazy
 from django.utils.translation import ugettext as _
 from django.utils.translation import ugettext_lazy
+from django.core.cache import cache
 
 from django.views.generic import (
     ListView,


### PR DESCRIPTION
#### What does this PR do?
Resets the cache after a muscle has been deleted
#### Description of Task to be completed?
It seems that after deleting a muscle, it keeps appearing in descriptions etc. This is probably due to the cache not being correctly reset.
The cache should be reset after a muscle has been deleted
#### How should this be manually tested?
Go to the heroku deploy for this branch,  log in as admin, navigate to exercises:
Under exercises, select a muscle and delete it out.
Take note of the muscle you have deleted. On checking again from the Muscle-overview,
the muscle should not be in the list.
#### What are the relevant pivotal tracker stories?
#149470685